### PR TITLE
Amend go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module nix-docker-go-flake-example
 
-go 1.23.0
+go 1.23
 
 toolchain go1.24.4
 


### PR DESCRIPTION
Remove trailing `.0` suffix from `minimum-go-version`.